### PR TITLE
8 allow for serial port reconnection

### DIFF
--- a/src/com_rx.py
+++ b/src/com_rx.py
@@ -8,10 +8,11 @@
 import string
 import sys
 import serial
-import threading
+import multiprocessing
+import utils
 
 
-class ComRxThread(threading.Thread):
+class ComRxThread(multiprocessing.Process):
     """
     A thread to receive values from the serial port and print them to the
     terminal.
@@ -27,7 +28,7 @@ class ComRxThread(threading.Thread):
         display : bool = False
             Weather to display non printable characters
         """
-        super().__init__(group=None)
+        super().__init__(group=None, name="com_rx_thread")
         
         printable_chars = string.printable
         self.printable_char_bytes = bytes(printable_chars, 'ascii')
@@ -40,7 +41,10 @@ class ComRxThread(threading.Thread):
         Run the com receive thread
         """
         while (True):
-            com_rx = self.serial_port.read(1)
+            try:
+                com_rx = self.serial_port.read(1)
+            except serial.SerialException:
+                utils.close_com_threads()
 
             if (com_rx == b''): # if empty don't print
                 continue

--- a/src/main.py
+++ b/src/main.py
@@ -6,12 +6,14 @@
 # and helper Functions
 
 import serial
+import datetime
 
-from get_char import getchar
+
 from cmd_args import setup_cmd_args
 from com_rx import ComRxThread
 from com_tx import ComTxThread
-import pty
+import utils
+
 
 from configuration import Config, ConfigDict
 
@@ -91,13 +93,14 @@ def open_serial_port(port: str, baud: int, data: int, parity: str,
             
         except serial.serialutil.SerialException:
             if (first_print):
-                print("Serial port open error please review settings")
+                print(f"{utils.get_time_str()} Serial port waiting to open" \
+                      "(Check settings if connected) \r")
 
             first_print = False
         except:
             exit(0)
 
-    print(f"Serial monitor started: {data}, {stop}, {baud}, {parity}")
+    print(f"{utils.get_time_str()} Serial monitor started: {data}, {stop}, {baud}, {parity}")
 
     return port
 
@@ -123,7 +126,7 @@ def main() -> None:
             current_cfg.serial.data, current_cfg.serial.parity, 
             current_cfg.serial.stop, 0.5)
 
-        print(f"In {current_cfg.mode} mode with display " \
+        print(f"{utils.get_time_str()} In {current_cfg.mode} mode with display " \
             f"{current_cfg.terminal.display_npc}.")
 
         com_tx_thread = ComTxThread(port, current_cfg.mode)
@@ -134,10 +137,11 @@ def main() -> None:
         com_tx_thread.start()
         com_rx_thread.start()
 
-        com_tx_thread.join()
-        print("exited tx")
         com_rx_thread.join()
-        print("exited Rx")
+        print(f"\r\n{utils.get_time_str()} Lost connection\r")
+        com_tx_thread.join()
+        
+
 
         port.close()
 

--- a/src/settings.json
+++ b/src/settings.json
@@ -1,6 +1,6 @@
 {
     "version": 1,
-    "mode": "local",
+    "mode": "dumb",
     "serial": {
         "port": "/dev/ttyUSB0",
         "baud": 115200,

--- a/src/settings.json
+++ b/src/settings.json
@@ -1,6 +1,6 @@
 {
     "version": 1,
-    "mode": "dumb",
+    "mode": "local",
     "serial": {
         "port": "/dev/ttyUSB0",
         "baud": 115200,

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,18 @@
+## 
+# @file utils.py
+# @author Jack Duignan (JackpDuignan@gmail.com)
+# @date 2024-07-22
+# @brief This file contains various helper functions for the project
+
+import threading
+
+def close_com_threads():
+    """
+    Close all serial port related threads using their name. This is not
+    the best way to do this but I can't think of a better one right now.
+    """
+    com_thread_names = ["com_rx_thread", "com_tx_thread"]
+
+    for thread in threading.enumerate():
+        if (thread.getName() in com_thread_names):
+            thread.

--- a/src/utils.py
+++ b/src/utils.py
@@ -5,6 +5,7 @@
 # @brief This file contains various helper functions for the project
 
 import threading
+import datetime
 
 def close_com_threads():
     """
@@ -15,4 +16,19 @@ def close_com_threads():
 
     for thread in threading.enumerate():
         if (thread.getName() in com_thread_names):
-            thread.
+            thread.stop()
+
+
+def get_time_str() -> str:
+    """
+    Get the current time and return it as a str to append at the start of
+    system messages.
+
+    ### Returns:
+    out : str
+        Print string
+    """
+    now = datetime.datetime.now()
+
+    return now.strftime("[%H:%M:%S]:")
+


### PR DESCRIPTION
This pull implements the ability to reconnect the serial terminal on device connection loss. Its currently flaw is that as getchar and input are blocking it requires another keyboard press in order to fully reconnect the terminal.